### PR TITLE
Adjust margin for vending machine purchase entries

### DIFF
--- a/src/modules/better-journal/modules/journal-styles/styles/custom-entries/location/birthday.css
+++ b/src/modules/better-journal/modules/journal-styles/styles/custom-entries/location/birthday.css
@@ -29,7 +29,7 @@
 }
 
 .journal .content .entry.vending_machine_purchase .journaltext {
-  margin-top: 16px;
+  margin-top: -5px;
   font-size: 10px;
   font-weight: 900;
   line-height: 12px;


### PR DESCRIPTION
### Description
This pull request adjusts the `margin-top` value in the CSS for vending machine purchase journal entries. This update ensures proper spacing and enhances the visual alignment of the entries.

Before:
![before](https://github.com/user-attachments/assets/d360c591-3349-41c1-b7bd-8b6dcc4e8ddd)
After: 
![after](https://github.com/user-attachments/assets/d6f0ef2f-3044-4c91-aa17-a59c77ea2edb)
